### PR TITLE
Handle signals

### DIFF
--- a/internal/app/asyncHandler.go
+++ b/internal/app/asyncHandler.go
@@ -53,5 +53,5 @@ func (h *AsyncHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AsyncHandler) enqueueWorkItem(ctx context.Context, workItem models.WorkItem) error {
-	return h.queue.Publish(ctx, workItem)
+	return h.queue.Publish(ctx, workItem, 0)
 }

--- a/internal/app/processor.go
+++ b/internal/app/processor.go
@@ -26,7 +26,7 @@ func NewWebhookProcessor(storage *SQLiteStorage, queue *queue.RabbitMQQueue, cac
 		storage:  storage,
 		queue:    queue,
 		cache:    cache,
-		executor: executor.NewExecutor(10),
+		executor: executor.NewExecutor(4),
 	}
 }
 
@@ -71,7 +71,7 @@ func (p *WebhookProcessor) ProcessWebhooks() {
 	}
 }
 
-func (p *WebhookProcessor) StopWebhooks() {
+func (p *WebhookProcessor) Stop() {
 	p.executor.Stop()
 }
 

--- a/internal/app/processor.go
+++ b/internal/app/processor.go
@@ -14,6 +14,8 @@ import (
 	"github.com/jasonwvh/webhook-handler/internal/queue"
 )
 
+const maxRetry int32 = 3
+
 type WebhookProcessor struct {
 	storage  *SQLiteStorage
 	queue    *queue.RabbitMQQueue
@@ -49,7 +51,7 @@ func (p *WebhookProcessor) ProcessWebhooks() {
 					if val, ok := d.Headers["retry"]; ok {
 						retry = val.(int32)
 					}
-					if retry > 3 {
+					if retry > maxRetry {
 						d.Ack(false)
 						continue
 					}

--- a/internal/app/processor.go
+++ b/internal/app/processor.go
@@ -3,10 +3,8 @@ package app
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/jasonwvh/webhook-handler/internal/executor"
@@ -66,7 +64,7 @@ func (p *WebhookProcessor) ProcessWebhooks() {
 					d.Ack(false)
 
 					p.cache.RemovePending(workItem.ID)
-					p.cache.SetSeq(workItem.URL, workItem.Seq)
+					// p.cache.SetSeq(workItem.URL, workItem.Seq)
 				})
 			}
 		}()
@@ -78,20 +76,20 @@ func (p *WebhookProcessor) Stop() {
 }
 
 func (p *WebhookProcessor) processWorkItem(workItem *models.WorkItem) error {
-	seq, err := p.cache.GetSeq(workItem.URL)
-	if err != nil {
-		// if url doesn't exist yet, create one
-		p.cache.SetSeq(workItem.URL, workItem.Seq)
-	}
-	seqInt, _ := strconv.Atoi(seq)
-	if err == nil && workItem.Seq != seqInt+1 {
-		// if the url is already processed and it's not the next sequence
-		return fmt.Errorf("work item not next in order")
-	}
+	// seq, err := p.cache.GetSeq(workItem.URL)
+	// if err != nil {
+	// 	// if url doesn't exist yet, create one
+	// 	p.cache.SetSeq(workItem.URL, workItem.Seq)
+	// }
+	// seqInt, _ := strconv.Atoi(seq)
+	// if err == nil && workItem.Seq != seqInt+1 {
+	// 	// if the url is already processed and it's not the next sequence
+	// 	return fmt.Errorf("work item not next in order")
+	// }
 	p.cache.AddPending(workItem.ID)
 
 	// Simulate work
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	resp, err := http.Get(workItem.URL)
 	if err != nil {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"log"
 	"sync"
 )
 
@@ -46,6 +47,7 @@ func (e *Executor) worker() {
 		case job := <-e.jobCh:
 			job()
 		case <-e.stopCh:
+			log.Printf("received kill worker signal")
 			return
 		}
 	}


### PR DESCRIPTION
#### Changes
- RabbitMQ retry counter with header to make it more robust
- Server app to handle signals such as `SIGTERM`

#### Expected Behaviours
- When the app receives `SIGTERM`, it will wait until the worker has finished the task to shut down
- When the app receives `SIGKILL`, it will shut down immediately. The message will not be `acked`, and thus will be reprocessed when the app restarts.